### PR TITLE
Refactor: `NowPlaying` -> `PlayerContext`

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -1,4 +1,4 @@
-use super::{now_playing::*, res_handler::*, titlebar::Titlebar};
+use super::{res_handler::*, titlebar::Titlebar};
 use crate::{
     control_bar::ControlBar, layout::Layout, main_view::MainView, queue_list::QueueList, sidebar::*,
 };

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -13,7 +13,6 @@ pub struct Kagi {
     pub control_bar: Entity<ControlBar>,
     pub main_view: Entity<MainView>,
     pub layout: Entity<Layout>,
-    pub now_playing: Entity<PlayerContext>,
     pub res_handler: Entity<ResHandler>,
 }
 

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -13,7 +13,7 @@ pub struct Kagi {
     pub control_bar: Entity<ControlBar>,
     pub main_view: Entity<MainView>,
     pub layout: Entity<Layout>,
-    pub now_playing: Entity<NowPlaying>,
+    pub now_playing: Entity<PlayerContext>,
     pub res_handler: Entity<ResHandler>,
 }
 

--- a/crates/ui/src/control_bar.rs
+++ b/crates/ui/src/control_bar.rs
@@ -7,11 +7,11 @@ use components::{
 use gpui::{prelude::FluentBuilder, *};
 use gstreamer::State;
 
-use crate::now_playing::NowPlaying;
+use crate::now_playing::PlayerContext;
 
 #[derive(Clone)]
 pub struct ControlBar {
-    now_playing: Entity<NowPlaying>,
+    now_playing: Entity<PlayerContext>,
     vol_slider: Entity<Slider>,
     playbar: Entity<Slider>,
 }
@@ -252,7 +252,7 @@ impl Render for ControlBar {
 
 impl ControlBar {
     pub fn new(
-        now_playing: Entity<NowPlaying>,
+        now_playing: Entity<PlayerContext>,
         vol_slider: Entity<Slider>,
         playbar: Entity<Slider>,
     ) -> Self {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
 
                     cx.set_global(controller);
                     cx.set_global(theme);
+                    cx.set_global(now_playing);
                     cx.background_executor()
                         .spawn(async move {
                             player.run().await;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -24,7 +24,7 @@ use control_bar::ControlBar;
 use gpui::*;
 use layout::Layout;
 use main_view::MainView;
-use now_playing::{NowPlaying, NowPlayingEvent, Thumbnail, Track};
+use now_playing::{PlayerContext, PlayerContextEvent, Thumbnail, Track};
 use queue_list::QueueList;
 use res_handler::ResHandler;
 use sidebar::LeftSidebar;
@@ -73,7 +73,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
             |_, cx| {
                 cx.new(|cx| {
                     let theme = Theme::default();
-                    let now_playing = NowPlaying::new();
+                    let now_playing = PlayerContext::new();
                     let np = cx.new(|_| now_playing.clone());
                     let res_handler = cx.new(|_| ResHandler {});
                     let arc_res = Arc::new(res_handler.clone());
@@ -160,10 +160,10 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                         &np,
                         move |this: &mut Kagi,
                               _,
-                              event: &NowPlayingEvent,
+                              event: &PlayerContextEvent,
                               cx: &mut Context<Kagi>| {
                             match event {
-                                NowPlayingEvent::Meta(title, album, artists, duration) => {
+                                PlayerContextEvent::Meta(title, album, artists, duration) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.title = title.clone();
                                         this.album = album.clone();
@@ -172,7 +172,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Position(pos) => {
+                                PlayerContextEvent::Position(pos) => {
                                     let np = &this.now_playing;
                                     np.update(cx, |this, _| {
                                         this.position = *pos;
@@ -185,43 +185,43 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Thumbnail(img) => {
+                                PlayerContextEvent::Thumbnail(img) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.thumbnail = Some(img.clone());
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::State(state) => {
+                                PlayerContextEvent::State(state) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.state = state.clone();
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Volume(vol) => {
+                                PlayerContextEvent::Volume(vol) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.volume = vol.clone();
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Tracks(tracks) => {
+                                PlayerContextEvent::Tracks(tracks) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.tracks = tracks.clone();
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::PlaylistName(name) => {
+                                PlayerContextEvent::PlaylistName(name) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.playlist_name = name.into();
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Shuffle(shuffle) => {
+                                PlayerContextEvent::Shuffle(shuffle) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.shuffle = shuffle.clone();
                                     });
                                     cx.notify();
                                 }
-                                NowPlayingEvent::Repeat(repeat) => {
+                                PlayerContextEvent::Repeat(repeat) => {
                                     this.now_playing.update(cx, |this, _| {
                                         this.repeat = repeat.clone();
                                     });

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                     })
                     .detach();
 
+                    let playbar_clone = playbar.clone();
                     cx.subscribe(
                         &res_handler,
                         move |_: &mut Kagi, _, event: &Response, cx| match event {
@@ -176,6 +177,17 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                     state.position = *pos;
                                     cx.notify();
                                 });
+                                let duration = cx
+                                    .global::<PlayerContext>()
+                                    .metadata
+                                    .read(cx)
+                                    .duration
+                                    .clone();
+                                let slider_value = (*pos as f64 / duration as f64) as f32;
+                                playbar_clone.update(cx, |this, cx| {
+                                    this.value(slider_value, cx);
+                                });
+                                cx.notify();
                             }
                             Response::StreamStart => cx.global::<Controller>().get_meta(),
                             Response::Metadata(track) => {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -329,17 +329,15 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                     .detach();
                     let layout = cx.new(|_| Layout::new());
 
-                    let titlebar = cx.new(|_| Titlebar::new(np.clone(), layout.clone()));
+                    let titlebar = cx.new(|_| Titlebar::new(layout.clone()));
 
-                    let control_bar = cx
-                        .new(|_| ControlBar::new(np.clone(), vol_slider.clone(), playbar.clone()));
-                    let main_view = cx.new(|_| MainView::new(np.clone(), layout.clone()));
-                    let queue_list = cx.new(|cx| QueueList::new(cx, np.clone(), layout.clone()));
+                    let control_bar =
+                        cx.new(|_| ControlBar::new(vol_slider.clone(), playbar.clone()));
+                    let main_view = cx.new(|_| MainView::new(layout.clone()));
+                    let queue_list = cx.new(|cx| QueueList::new(cx, layout.clone()));
                     let layout_sidebar = layout.clone();
-                    let np_sidebar = np.clone();
-                    let left_sidebar = cx.new(move |_| {
-                        LeftSidebar::new(playlists.clone(), layout_sidebar.clone(), np_sidebar)
-                    });
+                    let left_sidebar = cx
+                        .new(move |_| LeftSidebar::new(playlists.clone(), layout_sidebar.clone()));
                     cx.global::<Controller>().load_saved_playlists();
 
                     Kagi {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -73,7 +73,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
             |_, cx| {
                 cx.new(|cx| {
                     let theme = Theme::default();
-                    let now_playing = PlayerContext::new();
+                    let now_playing = PlayerContext::new(cx);
                     let np = cx.new(|_| now_playing.clone());
                     let res_handler = cx.new(|_| ResHandler {});
                     let arc_res = Arc::new(res_handler.clone());

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -24,7 +24,7 @@ use control_bar::ControlBar;
 use gpui::*;
 use layout::Layout;
 use main_view::MainView;
-use now_playing::{PlayerContext, PlayerContextEvent, Thumbnail, Track};
+use now_playing::{PlayerContext, Thumbnail, Track};
 use queue_list::QueueList;
 use res_handler::ResHandler;
 use sidebar::LeftSidebar;
@@ -74,7 +74,6 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                 cx.new(|cx| {
                     let theme = Theme::default();
                     let now_playing = PlayerContext::new(cx);
-                    let np = cx.new(|_| now_playing.clone());
                     let res_handler = cx.new(|_| ResHandler {});
                     let arc_res = Arc::new(res_handler.clone());
                     let (mut player, controller) =
@@ -158,85 +157,10 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                         }
                     })
                     .detach();
-                    let pb_clone = playbar.clone();
-                    // cx.subscribe(
-                    //     &np,
-                    //     move |this: &mut Kagi,
-                    //           _,
-                    //           event: &PlayerContextEvent,
-                    //           cx: &mut Context<Kagi>| {
-                    //         match event {
-                    //             PlayerContextEvent::Meta(title, album, artists, duration) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.title = title.clone();
-                    //                     this.album = album.clone();
-                    //                     this.artists = artists.clone();
-                    //                     this.duration = duration.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Position(pos) => {
-                    //                 let np = &this.now_playing;
-                    //                 np.update(cx, |this, _| {
-                    //                     this.position = *pos;
-                    //                 });
-                    //                 let total_duration = np.read(cx).duration;
-                    //                 let slider_value = (*pos as f64 / total_duration as f64) as f32;
 
-                    //                 pb_clone.update(cx, |this, cx| {
-                    //                     this.value(slider_value, cx);
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Thumbnail(img) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.thumbnail = Some(img.clone());
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::State(state) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.state = state.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Volume(vol) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.volume = vol.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Tracks(tracks) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.tracks = tracks.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::PlaylistName(name) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.playlist_name = name.into();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Shuffle(shuffle) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.shuffle = shuffle.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //             PlayerContextEvent::Repeat(repeat) => {
-                    //                 this.now_playing.update(cx, |this, _| {
-                    //                     this.repeat = repeat.clone();
-                    //                 });
-                    //                 cx.notify();
-                    //             }
-                    //         }
-                    //     },
-                    // )
-                    // .detach();
                     cx.subscribe(
                         &res_handler,
-                        move |this: &mut Kagi, _, event: &Response, cx| match event {
+                        move |_: &mut Kagi, _, event: &Response, cx| match event {
                             Response::Eos => {
                                 if cx.global::<PlayerContext>().state.read(cx).repeat {
                                     cx.global::<Controller>().seek(0);
@@ -264,7 +188,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                             }
                             Response::Thumbnail(thumbnail) => {
                                 let metadata = cx.global_mut::<PlayerContext>().metadata.clone();
-                                metadata.update(cx, |meta, cx| {
+                                metadata.update(cx, |meta, _| {
                                     meta.thumbnail = Some(Thumbnail {
                                         img: ImageSource::Render(
                                             RenderImage::new(thumbnail.clone().to_frame()).into(),

--- a/crates/ui/src/main_view.rs
+++ b/crates/ui/src/main_view.rs
@@ -5,13 +5,12 @@ use crate::{layout::Layout, now_playing::PlayerContext};
 
 #[derive(Clone)]
 pub struct MainView {
-    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
 impl Render for MainView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let np = self.now_playing.clone();
+        let meta = cx.global::<PlayerContext>().metadata.clone();
         let theme = cx.global::<Theme>();
         let layout = self.layout.clone().read(cx);
 
@@ -26,7 +25,7 @@ impl Render for MainView {
             .flex_col()
             .overflow_hidden()
             .child({
-                if let Some(thumbnail) = np.read(cx).thumbnail.clone() {
+                if let Some(thumbnail) = meta.read(cx).thumbnail.clone() {
                     div()
                         .w(px(layout.central_width))
                         .max_h(px(layout.central_width))
@@ -55,11 +54,11 @@ impl Render for MainView {
                     .flex_shrink_0()
                     .gap_2()
                     .child({
-                        let np = np.read(cx);
-                        if !np.title.is_empty() {
+                        let meta = meta.read(cx);
+                        if !meta.title.is_empty() {
                             div()
                                 .text_color(theme.accent)
-                                .child(np.title.clone())
+                                .child(meta.title.clone())
                                 .text_3xl()
                                 .font_weight(FontWeight::EXTRA_BOLD)
                                 .w_full()
@@ -70,14 +69,14 @@ impl Render for MainView {
                         }
                     })
                     .child({
-                        let np = np.read(cx);
-                        if !np.title.is_empty() {
+                        let meta = meta.read(cx);
+                        if !meta.title.is_empty() {
                             div()
                                 .text_color(theme.text)
                                 .text_xl()
                                 .font_weight(FontWeight::MEDIUM)
                                 .whitespace_normal()
-                                .child(format!("{} • {}", np.artists.join(", "), np.album))
+                                .child(format!("{} • {}", meta.artists.join(", "), meta.album))
                                 .w_full()
                                 .max_w_full()
                                 .text_align(TextAlign::Center)
@@ -90,10 +89,7 @@ impl Render for MainView {
 }
 
 impl MainView {
-    pub fn new(now_playing: Entity<PlayerContext>, layout: Entity<Layout>) -> Self {
-        MainView {
-            now_playing,
-            layout,
-        }
+    pub fn new(layout: Entity<Layout>) -> Self {
+        MainView { layout }
     }
 }

--- a/crates/ui/src/main_view.rs
+++ b/crates/ui/src/main_view.rs
@@ -1,11 +1,11 @@
 use components::theme::Theme;
 use gpui::*;
 
-use crate::{layout::Layout, now_playing::NowPlaying};
+use crate::{layout::Layout, now_playing::PlayerContext};
 
 #[derive(Clone)]
 pub struct MainView {
-    pub now_playing: Entity<NowPlaying>,
+    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
@@ -90,7 +90,7 @@ impl Render for MainView {
 }
 
 impl MainView {
-    pub fn new(now_playing: Entity<NowPlaying>, layout: Entity<Layout>) -> Self {
+    pub fn new(now_playing: Entity<PlayerContext>, layout: Entity<Layout>) -> Self {
         MainView {
             now_playing,
             layout,

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -3,16 +3,26 @@ use gstreamer::State;
 
 #[derive(Clone)]
 pub struct PlayerContext {
+    pub metadata: Entity<Metadata>,
+    pub state: Entity<PlayerState>,
+    pub tracks: Entity<Vec<Track>>,
+}
+
+#[derive(Clone)]
+pub struct Metadata {
     pub playlist_name: SharedString,
     pub title: SharedString,
     pub album: SharedString,
     pub artists: Vec<SharedString>,
-    pub position: u64,
     pub duration: u64,
     pub thumbnail: Option<Thumbnail>,
+}
+
+#[derive(Clone)]
+pub struct PlayerState {
+    pub position: u64,
     pub state: State,
     pub volume: f64,
-    pub tracks: Vec<Track>,
     pub shuffle: bool,
     pub repeat: bool,
 }

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -56,21 +56,37 @@ pub enum PlayerContextEvent {
     Repeat(bool),
 }
 
-impl PlayerContext {
+impl Metadata {
     pub fn new() -> Self {
-        PlayerContext {
+        Metadata {
             playlist_name: "".into(),
             title: "".into(),
-            artists: vec!["".into()],
             album: "".into(),
-            position: 0,
+            artists: vec!["".into()],
             duration: 0,
             thumbnail: None,
+        }
+    }
+}
+
+impl PlayerState {
+    pub fn new() -> Self {
+        PlayerState {
+            position: 0,
             state: State::Null,
             volume: 0.2,
-            tracks: vec![],
             shuffle: false,
             repeat: false,
+        }
+    }
+}
+
+impl PlayerContext {
+    pub fn new(cx: &mut App) -> Self {
+        PlayerContext {
+            metadata: cx.new(|_| Metadata::new()),
+            state: cx.new(|_| PlayerState::new()),
+            tracks: cx.new(|_| vec![]),
         }
     }
 

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -81,6 +81,8 @@ impl PlayerState {
     }
 }
 
+impl Metadata {}
+
 impl PlayerContext {
     pub fn new(cx: &mut App) -> Self {
         PlayerContext {

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -2,7 +2,7 @@ use gpui::*;
 use gstreamer::State;
 
 #[derive(Clone)]
-pub struct NowPlaying {
+pub struct PlayerContext {
     pub playlist_name: SharedString,
     pub title: SharedString,
     pub album: SharedString,
@@ -34,7 +34,7 @@ pub struct Track {
     pub thumbnail: Option<Thumbnail>,
 }
 
-pub enum NowPlayingEvent {
+pub enum PlayerContextEvent {
     Meta(SharedString, SharedString, Vec<SharedString>, u64),
     Position(u64),
     Thumbnail(Thumbnail),
@@ -46,9 +46,9 @@ pub enum NowPlayingEvent {
     Repeat(bool),
 }
 
-impl NowPlaying {
+impl PlayerContext {
     pub fn new() -> Self {
-        NowPlaying {
+        PlayerContext {
             playlist_name: "".into(),
             title: "".into(),
             artists: vec!["".into()],
@@ -72,50 +72,50 @@ impl NowPlaying {
         artists: Vec<SharedString>,
         duration: u64,
     ) {
-        cx.emit(NowPlayingEvent::Meta(title, album, artists, duration));
+        cx.emit(PlayerContextEvent::Meta(title, album, artists, duration));
         cx.notify();
     }
 
     pub fn update_pos(&mut self, cx: &mut Context<Self>, pos: u64) {
-        cx.emit(NowPlayingEvent::Position(pos));
+        cx.emit(PlayerContextEvent::Position(pos));
         cx.notify();
     }
 
     pub fn update_thumbnail(&mut self, cx: &mut Context<Self>, thumbnail: Thumbnail) {
-        cx.emit(NowPlayingEvent::Thumbnail(thumbnail));
+        cx.emit(PlayerContextEvent::Thumbnail(thumbnail));
         cx.notify();
     }
 
     pub fn update_state(&mut self, cx: &mut Context<Self>, state: State) {
-        cx.emit(NowPlayingEvent::State(state));
+        cx.emit(PlayerContextEvent::State(state));
         cx.notify();
     }
 
     pub fn update_vol(&mut self, cx: &mut Context<Self>, vol: f64) {
-        cx.emit(NowPlayingEvent::Volume(vol));
+        cx.emit(PlayerContextEvent::Volume(vol));
         cx.notify();
     }
 
     pub fn update_tracks(&mut self, cx: &mut Context<Self>, tracks: Vec<Track>) {
-        cx.emit(NowPlayingEvent::Tracks(tracks));
+        cx.emit(PlayerContextEvent::Tracks(tracks));
         cx.notify();
     }
 
     pub fn update_playlist_name(&mut self, cx: &mut Context<Self>, name: String) {
-        cx.emit(NowPlayingEvent::PlaylistName(name));
+        cx.emit(PlayerContextEvent::PlaylistName(name));
         cx.notify();
     }
 
     pub fn update_shuffle(&mut self, cx: &mut Context<Self>, shuffle: bool) {
-        cx.emit(NowPlayingEvent::Shuffle(shuffle));
+        cx.emit(PlayerContextEvent::Shuffle(shuffle));
         cx.notify();
     }
 
     pub fn update_repeat(&mut self, cx: &mut Context<Self>, repeat: bool) {
-        cx.emit(NowPlayingEvent::Repeat(repeat));
+        cx.emit(PlayerContextEvent::Repeat(repeat));
         cx.notify();
     }
 }
 
-impl EventEmitter<NowPlayingEvent> for NowPlaying {}
-impl Global for NowPlaying {}
+impl EventEmitter<PlayerContextEvent> for PlayerContext {}
+impl Global for PlayerContext {}

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -8,11 +8,11 @@ use std::sync::Arc;
 
 use crate::{
     layout::{Layout, LayoutMode},
-    now_playing::{NowPlaying, Track},
+    now_playing::{PlayerContext, Track},
 };
 
 pub struct QueueList {
-    pub now_playing: Entity<NowPlaying>,
+    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
     pub nucleo: Nucleo<(usize, String)>,
     pub query: Entity<String>,
@@ -141,7 +141,7 @@ impl Render for QueueList {
 impl QueueList {
     pub fn new(
         cx: &mut Context<QueueList>,
-        now_playing: Entity<NowPlaying>,
+        now_playing: Entity<PlayerContext>,
         layout: Entity<Layout>,
     ) -> Self {
         let query = cx.new(|_| String::new());

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 
 pub struct QueueList {
-    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
     pub nucleo: Nucleo<(usize, String)>,
     pub query: Entity<String>,
@@ -29,10 +28,8 @@ impl Focusable for QueueList {
 
 impl Render for QueueList {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let tracks = self.search(
-            self.now_playing.read(cx).tracks.clone(),
-            self.query.read(cx).clone(),
-        );
+        let tracks = cx.global::<PlayerContext>().tracks.clone();
+        let tracks = self.search(tracks.read(cx).clone(), self.query.read(cx).clone());
 
         let theme = cx.global::<Theme>();
         let layout = self.layout.clone().read(cx);
@@ -139,11 +136,7 @@ impl Render for QueueList {
 }
 
 impl QueueList {
-    pub fn new(
-        cx: &mut Context<QueueList>,
-        now_playing: Entity<PlayerContext>,
-        layout: Entity<Layout>,
-    ) -> Self {
+    pub fn new(cx: &mut Context<QueueList>, layout: Entity<Layout>) -> Self {
         let query = cx.new(|_| String::new());
         let handle = cx.focus_handle();
 
@@ -161,7 +154,6 @@ impl QueueList {
         .detach();
 
         QueueList {
-            now_playing,
             layout,
             nucleo,
             query,

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -4,13 +4,13 @@ use gpui::{prelude::FluentBuilder, *};
 
 use crate::{
     layout::{Layout, LayoutMode},
-    now_playing::NowPlaying,
+    now_playing::PlayerContext,
 };
 
 #[derive(Clone)]
 pub struct LeftSidebar {
     pub playlists: Entity<SavedPlaylists>,
-    pub now_playing: Entity<NowPlaying>,
+    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
@@ -104,7 +104,7 @@ impl LeftSidebar {
     pub fn new(
         playlists: Entity<SavedPlaylists>,
         layout: Entity<Layout>,
-        now_playing: Entity<NowPlaying>,
+        now_playing: Entity<PlayerContext>,
     ) -> Self {
         LeftSidebar {
             playlists,

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -10,7 +10,6 @@ use crate::{
 #[derive(Clone)]
 pub struct LeftSidebar {
     pub playlists: Entity<SavedPlaylists>,
-    pub now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
@@ -19,7 +18,7 @@ impl Render for LeftSidebar {
         let theme = cx.global::<Theme>();
         let controller = cx.global::<Controller>().clone();
         let playlists = self.playlists.read(cx).clone().playlists;
-        let current_index = self.now_playing.clone();
+        let current_index = cx.global::<PlayerContext>().metadata.clone();
         let layout = self.layout.clone().read(cx);
 
         if layout.left_sidebar.show {
@@ -66,8 +65,8 @@ impl Render for LeftSidebar {
                         .truncate()
                         .on_mouse_down(MouseButton::Left, {
                             move |_, _, cx| {
-                                curr_index.update(cx, |this, cx| {
-                                    this.update_playlist_name(cx, playlist.name.clone());
+                                curr_index.update(cx, |this, _| {
+                                    this.playlist_name = playlist.name.clone().into();
                                 });
                                 controller.load(playlist.clone());
                                 controller.get_queue();
@@ -101,15 +100,7 @@ impl Render for LeftSidebar {
 }
 
 impl LeftSidebar {
-    pub fn new(
-        playlists: Entity<SavedPlaylists>,
-        layout: Entity<Layout>,
-        now_playing: Entity<PlayerContext>,
-    ) -> Self {
-        LeftSidebar {
-            playlists,
-            layout,
-            now_playing,
-        }
+    pub fn new(playlists: Entity<SavedPlaylists>, layout: Entity<Layout>) -> Self {
+        LeftSidebar { playlists, layout }
     }
 }

--- a/crates/ui/src/titlebar.rs
+++ b/crates/ui/src/titlebar.rs
@@ -1,5 +1,5 @@
 use crate::layout::Layout;
-use crate::now_playing::NowPlaying;
+use crate::now_playing::PlayerContext;
 use components::theme::Theme;
 
 use components::icon::*;
@@ -8,7 +8,7 @@ use prelude::FluentBuilder;
 
 #[derive(Clone)]
 pub struct Titlebar {
-    now_playing: Entity<NowPlaying>,
+    now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
@@ -200,7 +200,7 @@ impl Render for Titlebar {
 }
 
 impl Titlebar {
-    pub fn new(now_playing: Entity<NowPlaying>, layout: Entity<Layout>) -> Titlebar {
+    pub fn new(now_playing: Entity<PlayerContext>, layout: Entity<Layout>) -> Titlebar {
         Titlebar {
             now_playing,
             layout,

--- a/crates/ui/src/titlebar.rs
+++ b/crates/ui/src/titlebar.rs
@@ -8,7 +8,6 @@ use prelude::FluentBuilder;
 
 #[derive(Clone)]
 pub struct Titlebar {
-    now_playing: Entity<PlayerContext>,
     pub layout: Entity<Layout>,
 }
 
@@ -66,7 +65,7 @@ impl Render for Titlebar {
                     .items_center()
                     .justify_center()
                     .child({
-                        let np = self.now_playing.read(cx);
+                        let meta = cx.global::<PlayerContext>().metadata.read(cx);
                         let window_width = win.window_bounds().get_bounds().size.width.0;
 
                         let truncate = |text: &str, limit: usize| -> String {
@@ -84,42 +83,42 @@ impl Render for Titlebar {
                             .when(window_width < 200.0, |this| this.child("Kagi"))
                             .when((200.0..400.0).contains(&window_width), |this| {
                                 this.child({
-                                    if np.title.is_empty() {
+                                    if meta.title.is_empty() {
                                         "Kagi".to_string()
                                     } else {
-                                        truncate(&np.title, 30)
+                                        truncate(&meta.title, 30)
                                     }
                                 })
                             })
                             .when((400.0..600.0).contains(&window_width), |this| {
-                                if np.title.is_empty() {
+                                if meta.title.is_empty() {
                                     this.child("No Song Playing".to_string())
                                 } else {
-                                    let artists = if np.artists.is_empty() {
+                                    let artists = if meta.artists.is_empty() {
                                         "".to_string()
                                     } else {
-                                        format!(" - {}", np.artists.join(", "))
+                                        format!(" - {}", meta.artists.join(", "))
                                     };
-                                    this.child(format!("{}{}", truncate(&np.title, 30), artists))
+                                    this.child(format!("{}{}", truncate(&meta.title, 30), artists))
                                 }
                             })
                             .when(window_width >= 600.0, |this| {
-                                if np.title.is_empty() {
+                                if meta.title.is_empty() {
                                     this.child("Kagi".to_string())
                                 } else {
-                                    let artists = if np.artists.is_empty() {
+                                    let artists = if meta.artists.is_empty() {
                                         "".to_string()
                                     } else {
-                                        format!(" - {}", np.artists.join(", "))
+                                        format!(" - {}", meta.artists.join(", "))
                                     };
-                                    let album = if np.album.is_empty() {
+                                    let album = if meta.album.is_empty() {
                                         "".to_string()
                                     } else {
-                                        format!(" ({})", np.album)
+                                        format!(" ({})", meta.album)
                                     };
                                     this.child(format!(
                                         "{}{}{}",
-                                        truncate(&np.title, 30),
+                                        truncate(&meta.title, 30),
                                         artists,
                                         album
                                     ))
@@ -200,10 +199,7 @@ impl Render for Titlebar {
 }
 
 impl Titlebar {
-    pub fn new(now_playing: Entity<PlayerContext>, layout: Entity<Layout>) -> Titlebar {
-        Titlebar {
-            now_playing,
-            layout,
-        }
+    pub fn new(layout: Entity<Layout>) -> Titlebar {
+        Titlebar { layout }
     }
 }


### PR DESCRIPTION
This PR renames the `NowPlaying` struct to `PlayerContext`. The previous name was pretty vague and not very professional, new one sounds better. The struct was also split into different parts based on what made sense.

Probably more than that, the most breaking change was making the `PlayerContext`, previously `NowPlaying`, a `gpui::Global`. Now, we dont need to pass around a copy of that struct, whatever ya wanna call it, to every fucking component that needs it. Plan to do the same with the `Layout` and any new shit as well.