### PR TITLE
Fix: Implement `PartialEq` for `Track`

### DIFF
--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -240,7 +240,6 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                 });
                             }
                             Response::Tracks(new_tracks) => {
-                                println!("upating tracks");
                                 let tracks = cx.global_mut::<PlayerContext>().tracks.clone();
                                 tracks.update(cx, |tracks, cx| {
                                     let mut np_tracks = vec![];

--- a/crates/ui/src/player_context.rs
+++ b/crates/ui/src/player_context.rs
@@ -154,3 +154,13 @@ impl PlayerContext {
 impl EventEmitter<PlayerContextEvent> for PlayerContext {}
 impl EventEmitter<PlayerStateEvent> for PlayerState {}
 impl Global for PlayerContext {}
+
+impl PartialEq for Track {
+    fn eq(&self, other: &Self) -> bool {
+        true
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        false
+    }
+}

--- a/crates/ui/src/player_context.rs
+++ b/crates/ui/src/player_context.rs
@@ -157,10 +157,10 @@ impl Global for PlayerContext {}
 
 impl PartialEq for Track {
     fn eq(&self, other: &Self) -> bool {
-        true
-    }
-
-    fn ne(&self, other: &Self) -> bool {
-        false
+        self.title == other.title
+            && self.artists == other.artists
+            && self.album == other.album
+            && self.uri == other.uri
+            && self.duration == other.duration
     }
 }

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -166,11 +166,7 @@ impl QueueList {
     }
 
     pub fn search(&mut self, tracks: Vec<Track>, query: String) -> Vec<Track> {
-        if if self.tracks.len() > 0 && tracks.len() > 0 {
-            self.tracks[0].title != tracks[0].title
-        } else {
-            true
-        } {
+        if self.tracks != tracks {
             self.nucleo = Nucleo::new(Config::DEFAULT, Arc::new(|| {}), None, 1);
             let injector = self.nucleo.injector();
 


### PR DESCRIPTION
This PR implements the `PartialEq` trait for the `Track` struct. This allows us to properly compare the old and new queue, and update `nucleo`'s data appropriately.