### PR TITLE
Fix: UI cleanup

### DIFF
--- a/crates/components/src/icon.rs
+++ b/crates/components/src/icon.rs
@@ -97,6 +97,7 @@ impl RenderOnce for Icon {
             .justify_center()
             .size(px(self.size))
             .text_color(self.color)
+            .hover(|this| this.text_color(self.hover))
             .path(self.icon.path())
     }
 }

--- a/crates/ui/src/control_bar.rs
+++ b/crates/ui/src/control_bar.rs
@@ -151,10 +151,7 @@ impl Render for ControlBar {
                                         Icon::new(Icons::Rewind)
                                             .size(22.0)
                                             .color(theme.control_bar.text)
-                                            .hover(theme.control_bar.hover)
-                                            .when(state.shuffle, |this| {
-                                                this.color(theme.control_bar.hover)
-                                            }),
+                                            .hover(theme.control_bar.hover),
                                     )
                                     .on_mouse_down(MouseButton::Left, {
                                         {
@@ -228,10 +225,7 @@ impl Render for ControlBar {
                                         Icon::new(Icons::FastForward)
                                             .size(22.0)
                                             .color(theme.control_bar.text)
-                                            .hover(theme.control_bar.hover)
-                                            .when(state.shuffle, |this| {
-                                                this.color(theme.control_bar.hover)
-                                            }),
+                                            .hover(theme.control_bar.hover),
                                     )
                                     .on_mouse_down(MouseButton::Left, {
                                         {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -257,7 +257,8 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                 saved_playlists.update(cx, |this, cx| {
                                     *this = playlists.clone();
                                     cx.notify();
-                                })
+                                });
+                                cx.refresh_windows();
                             }
                             Response::PlaylistName(name) => {
                                 let meta = cx.global_mut::<PlayerContext>().metadata.clone();
@@ -275,11 +276,6 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                             }
                             Response::Theme(theme) => {
                                 cx.set_global::<Theme>(theme.clone().into());
-                                println!(
-                                    "{:#?}",
-                                    <Theme as From<backend::theme::Theme>>::from(theme.clone())
-                                        .clone()
-                                );
                                 cx.refresh_windows();
                             }
                             _ => {}

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -254,6 +254,7 @@ impl Render for RightSidebar {
                         tracks.len(),
                         move |_, range, _, cx| {
                             let theme = cx.global::<Theme>();
+                            let meta = cx.global::<PlayerContext>().metadata.clone();
 
                             range
                                 .map(|id| {
@@ -281,6 +282,9 @@ impl Render for RightSidebar {
                                                 .border_1()
                                                 .border_color(theme.right_sidebar.item_border)
                                                 .hover(|this| {
+                                                    this.bg(theme.right_sidebar.item_hover)
+                                                })
+                                                .when(meta.read(cx).title == track.title, |this| {
                                                     this.bg(theme.right_sidebar.item_hover)
                                                 })
                                                 .on_mouse_down(

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -8,7 +8,7 @@ use nucleo::{
     Config, Nucleo,
     pattern::{CaseMatching, Normalization},
 };
-use std::{collections::HashSet, time::Duration};
+use std::collections::HashSet;
 use std::{path::PathBuf, sync::Arc};
 
 use crate::{
@@ -23,7 +23,7 @@ pub struct LeftSidebar {
 
 pub struct LeftSidebarItem {
     playlist: SavedPlaylist,
-    hovered: bool,
+    // hovered: bool,
 }
 
 pub struct RightSidebar {
@@ -173,7 +173,7 @@ impl LeftSidebarItem {
     pub fn new(playlist: SavedPlaylist) -> Self {
         LeftSidebarItem {
             playlist,
-            hovered: false,
+            // hovered: false,
         }
     }
 }


### PR DESCRIPTION
cleans up shit i forgot in the last PR. also highlight current playing track. more importantly, playlist thumbnail generation only takes one track from any album in case multiple tracks from that album exist.